### PR TITLE
Account for empty (but still present) layers

### DIFF
--- a/core/handlers/layer.py
+++ b/core/handlers/layer.py
@@ -53,7 +53,7 @@ def child_keys(label, version):
 def get(name, label, version):
     """Find and return the layer with this name + version + label"""
     layer = db.Layers().get(name, label, version)
-    if layer:
+    if layer is not None:
         return success(layer)
     else:
         abort(404)

--- a/tests/handlers_layer_tests.py
+++ b/tests/handlers_layer_tests.py
@@ -153,3 +153,11 @@ class HandlersLayerTest(FlaskTest):
         response = self.client.get('/layer/nnn/lll/vvv')
         self.assertEqual(200, response.status_code)
         self.assertEqual({'example': 'response'}, json.loads(response.data))
+
+    @patch('core.handlers.layer.db')
+    def test_get_results_empty_layer(self, db):
+        db.Layers.return_value.get.return_value = {}
+        response = self.client.get('/layer/nnn/lll/vvv')
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({}, json.loads(response.data))
+


### PR DESCRIPTION
Check for None explicitly, instead of allowing {} to trigger a 404.
