### PR TITLE
Quick fix to see search results

### DIFF
--- a/core/handlers/search.py
+++ b/core/handlers/search.py
@@ -19,4 +19,4 @@ def search():
     es = ElasticSearch(settings.ELASTIC_SEARCH_URLS)
     results = es.search(query, index=settings.ELASTIC_SEARCH_INDEX)
 
-    return success(results['hits']['hits'])
+    return success({'results': results['hits']['hits']})


### PR DESCRIPTION
At some point, dictionaries became required for responses

This search is literally a pass through to elastic search -- it doesn't even filter by version
