### PR TITLE
Add MIDDLEWARE_CLASSES

### DIFF
--- a/regcore/example_settings.py
+++ b/regcore/example_settings.py
@@ -2,6 +2,10 @@ INSTALLED_APPS = [
     'regcore'
 ]
 
+MIDDLEWARE_CLASSES = (
+    'django.middleware.common.CommonMiddleware',
+)
+
 SECRET_KEY = 'v^p)1cwc)%td*szt7lt-(nl=bf)k07t%65*t(mi1f!*18dz9m@'
 
 DATABASES = {}


### PR DESCRIPTION
Otherwise it defaults to include CSRF, which we don't want.

This was not caught by tests because the django client includes CSRF.
