### PR TITLE
Allow CSRF protection middleware. Use default middleware in the example settings

### DIFF
--- a/regcore/example_settings.py
+++ b/regcore/example_settings.py
@@ -5,10 +5,6 @@ INSTALLED_APPS = [
     'south'
 ]
 
-MIDDLEWARE_CLASSES = (
-    'django.middleware.common.CommonMiddleware',
-)
-
 SECRET_KEY = 'v^p)1cwc)%td*szt7lt-(nl=bf)k07t%65*t(mi1f!*18dz9m@'
 
 DATABASES = {

--- a/regcore/urls_utils.py
+++ b/regcore/urls_utils.py
@@ -1,5 +1,6 @@
 from django.conf.urls import url
 from django.http import Http404, HttpResponseNotAllowed
+from django.views.decorators.csrf import csrf_exempt
 
 
 def by_verb_url(regex, name, by_verb):
@@ -11,4 +12,7 @@ def by_verb_url(regex, name, by_verb):
             return by_verb[verb](request, *args, **kwargs)
         else:
             return HttpResponseNotAllowed(by_verb.keys())
+    if any(getattr(fn, 'csrf_exempt', False) for fn in by_verb.values()):
+        wrapper = csrf_exempt(wrapper)
+
     return url(regex, wrapper, name=name)

--- a/regcore_write/views/diff.py
+++ b/regcore_write/views/diff.py
@@ -1,9 +1,11 @@
 import anyjson
+from django.views.decorators.csrf import csrf_exempt
 
 from regcore import db
 from regcore.responses import success, user_error
 
 
+@csrf_exempt
 def add(request, label_id, old_version, new_version):
     """Add the diff to the db, indexed by the label and versions"""
     try:

--- a/regcore_write/views/layer.py
+++ b/regcore_write/views/layer.py
@@ -1,4 +1,5 @@
 import anyjson
+from django.views.decorators.csrf import csrf_exempt
 
 from regcore import db
 from regcore.responses import success, user_error
@@ -20,6 +21,7 @@ def child_label_of(lhs, rhs):
     return False
 
 
+@csrf_exempt
 def add(request, name, label_id, version):
     """Add the layer node and all of its children to the db"""
     try:

--- a/regcore_write/views/notice.py
+++ b/regcore_write/views/notice.py
@@ -1,9 +1,11 @@
 import anyjson
+from django.views.decorators.csrf import csrf_exempt
 
 from regcore import db
 from regcore.responses import success, user_error
 
 
+@csrf_exempt
 def add(request, docnum):
     """Add the notice to the db"""
     try:

--- a/regcore_write/views/regulation.py
+++ b/regcore_write/views/regulation.py
@@ -1,5 +1,5 @@
 import anyjson
-
+from django.views.decorators.csrf import csrf_exempt
 import jsonschema
 
 from regcore import db
@@ -29,6 +29,7 @@ REGULATION_SCHEMA = {
 }
 
 
+@csrf_exempt
 def add(request, label_id, version):
     """Add this regulation node and all of its children to the db"""
     try:


### PR DESCRIPTION
We assumed that the csrf protection middleware would not be installed. This change allows said middleware by effectively ignoring it for all PUT requests.
