### PR TITLE
Allow the verb used for adding content to be replaced

### DIFF
--- a/regcore/example_settings.py
+++ b/regcore/example_settings.py
@@ -18,8 +18,6 @@ TEST_RUNNER = 'django_nose.runner.NoseTestSuiteRunner'
 
 ROOT_URLCONF = 'regcore.urls'
 
-WRITE_VERB = 'PUT'
-
 DEBUG = True
 
 BACKENDS = {

--- a/regcore/urls.py
+++ b/regcore/urls.py
@@ -11,11 +11,6 @@ from regcore_write.views import notice as wnotice, regulation as wregulation
 from regcore.urls_utils import by_verb_url
 
 
-# Migration strategy for settings files
-if not hasattr(settings, 'WRITE_VERB'):
-    settings.WRITE_VERB = 'PUT'
-
-
 mapping = defaultdict(dict)
 
 
@@ -30,10 +25,12 @@ if 'regcore_read' in settings.INSTALLED_APPS:
 
 
 if 'regcore_write' in settings.INSTALLED_APPS:
-    mapping['diff'][settings.WRITE_VERB] = wdiff.add
-    mapping['layer'][settings.WRITE_VERB] = wlayer.add
-    mapping['notice'][settings.WRITE_VERB] = wnotice.add
-    mapping['regulation'][settings.WRITE_VERB] = wregulation.add
+    # Allow both PUT and POST
+    for verb in ('PUT', 'POST'):
+        mapping['diff'][verb] = wdiff.add
+        mapping['layer'][verb] = wlayer.add
+        mapping['notice'][verb] = wnotice.add
+        mapping['regulation'][verb] = wregulation.add
 
 
 # Re-usable URL patterns.

--- a/regcore_write/tests/views_diff_tests.py
+++ b/regcore_write/tests/views_diff_tests.py
@@ -16,13 +16,6 @@ class ViewsDiffTest(TestCase):
                                 data='{Invalid}')
         self.assertEqual(400, response.status_code)
 
-    def test_add_post(self):
-        url = '/diff/lablab/oldold/newnew'
-
-        response = Client().post(url, content_type='application/json',
-                                 data=json.dumps({'some': 'struct'}))
-        self.assertEqual(405, response.status_code)
-
     @patch('regcore_write.views.diff.db')
     def test_add_label_success(self, db):
         url = '/diff/lablab/oldold/newnew'

--- a/regcore_write/tests/views_layer_tests.py
+++ b/regcore_write/tests/views_layer_tests.py
@@ -23,13 +23,6 @@ class ViewsLayerTest(TestCase):
                                 data=json.dumps({'nonlab': []}))
         self.assertEqual(400, response.status_code)
 
-    def test_add_post(self):
-        url = '/layer/layname/lablab/verver'
-
-        response = Client().post(url, content_type='application/json',
-                                 data=json.dumps({'lablab': []}))
-        self.assertEqual(405, response.status_code)
-
     @patch('regcore_write.views.layer.db')
     def test_add_success(self, db):
         url = '/layer/layname/lablab/verver'

--- a/regcore_write/tests/views_notice_tests.py
+++ b/regcore_write/tests/views_notice_tests.py
@@ -16,13 +16,6 @@ class ViewsNoticeTest(TestCase):
                                 data='{Invalid}')
         self.assertEqual(400, response.status_code)
 
-    def test_add_post(self):
-        url = '/notice/docdoc'
-
-        response = Client().post(url, content_type='application/json',
-                                 data=json.dumps({'some': 'struct'}))
-        self.assertEqual(405, response.status_code)
-
     @patch('regcore_write.views.notice.db')
     def test_add_label_success(self, db):
         url = '/notice/docdoc'

--- a/regcore_write/tests/views_regulation_tests.py
+++ b/regcore_write/tests/views_regulation_tests.py
@@ -41,15 +41,6 @@ class ViewsRegulationTest(TestCase):
                                 data=json.dumps(message))
         self.assertEqual(400, response.status_code)
 
-    def test_add_post(self):
-        url = '/regulation/lablab/verver'
-
-        message = {'text': '', 'children': [],
-                   'label': ['notlablab']}
-        response = Client().post(url, content_type='application/json',
-                                 data=json.dumps(message))
-        self.assertEqual(405, response.status_code)
-
     @patch('regcore_write.views.regulation.db')
     def test_add_label_success(self, db):
         url = '/regulation/p/verver'
@@ -68,6 +59,7 @@ class ViewsRegulationTest(TestCase):
                 'children': []
             }]
         }
+
         response = Client().put(url, content_type='application/json',
                                 data=json.dumps(message))
         self.assertTrue(db.Regulations.return_value.bulk_put.called)
@@ -82,6 +74,13 @@ class ViewsRegulationTest(TestCase):
             if arg['label'] == ['p', 'c2']:
                 found[2] = True
         self.assertEqual(found, [True, True, True])
+
+        db.Regulations.return_value.bulk_put.reset_mock()
+        response = Client().post(url, content_type='application/json',
+                                 data=json.dumps(message))
+        self.assertTrue(db.Regulations.return_value.bulk_put.called)
+        bulk_put_args = db.Regulations.return_value.bulk_put.call_args[0]
+        self.assertEqual(3, len(bulk_put_args[0]))
 
     @patch('regcore_write.views.regulation.db')
     def test_add_empty_children(self, db):


### PR DESCRIPTION
Let me know what you think about providing a migration strategy within urls.py -- I don't want to break existing installs.
