### PR TITLE
Don't escape entities when writing them to solr

### DIFF
--- a/regcore/templates/search/indexes/regcore/regulation_text.txt
+++ b/regcore/templates/search/indexes/regcore/regulation_text.txt
@@ -1,1 +1,1 @@
-{{ object.text }}
+{{ object.text|safe }}


### PR DESCRIPTION
If these are escaped (as django does), they will come out of the API (when searching) with HTML entities. We don't need that (particularly since the data isn't escaped when placed into the DB).
