### PR TITLE
Set root for all existing regulations

### DIFF
--- a/regcore/migrations/0005_set_root_regs.py
+++ b/regcore/migrations/0005_set_root_regs.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        "Write your forwards methods here."
+        for reg in orm.Regulation.objects.exclude(label_string__contains="-"):
+            reg.root = True
+            reg.save()
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+        # Rather than risk reverting roots made before this migration, just
+        # keep everything
+
+    models = {
+        u'regcore.diff': {
+            'Meta': {'unique_together': "(('label', 'old_version', 'new_version'),)", 'object_name': 'Diff', 'index_together': "(('label', 'old_version', 'new_version'),)"},
+            'diff': ('regcore.fields.CompressedJSONField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.SlugField', [], {'max_length': '50'}),
+            'new_version': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
+            'old_version': ('django.db.models.fields.SlugField', [], {'max_length': '20'})
+        },
+        u'regcore.layer': {
+            'Meta': {'unique_together': "(('version', 'name', 'label'),)", 'object_name': 'Layer', 'index_together': "(('version', 'name', 'label'),)"},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.SlugField', [], {'max_length': '50'}),
+            'layer': ('regcore.fields.CompressedJSONField', [], {}),
+            'name': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
+            'version': ('django.db.models.fields.SlugField', [], {'max_length': '20'})
+        },
+        u'regcore.notice': {
+            'Meta': {'object_name': 'Notice'},
+            'cfr_part': ('django.db.models.fields.SlugField', [], {'max_length': '10'}),
+            'document_number': ('django.db.models.fields.SlugField', [], {'max_length': '20', 'primary_key': 'True'}),
+            'effective_on': ('django.db.models.fields.DateField', [], {'null': 'True'}),
+            'fr_url': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'notice': ('regcore.fields.CompressedJSONField', [], {}),
+            'publication_date': ('django.db.models.fields.DateField', [], {})
+        },
+        u'regcore.regulation': {
+            'Meta': {'unique_together': "(('version', 'label_string'),)", 'object_name': 'Regulation', 'index_together': "(('version', 'label_string'),)"},
+            'children': ('regcore.fields.CompressedJSONField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label_string': ('django.db.models.fields.SlugField', [], {'max_length': '50'}),
+            'node_type': ('django.db.models.fields.SlugField', [], {'max_length': '10'}),
+            'root': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'text': ('django.db.models.fields.TextField', [], {}),
+            'title': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'version': ('django.db.models.fields.SlugField', [], {'max_length': '20'})
+        }
+    }
+
+    complete_apps = ['regcore']
+    symmetrical = True


### PR DESCRIPTION
This resolves a problem with data created before #35. Even though those regulations may have been a root, they weren't marked appropriately. 
