### PR TITLE
Add wsgi to buildout config

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -16,6 +16,7 @@ recipe = djangorecipe
 project = regcore
 settings = example_settings
 test = regcore regcore_read regcore_write
+wsgi = true
 eggs = ${buildout:eggs}
        anyjson
        django-haystack


### PR DESCRIPTION
This PR simply adds wsgi to the buildout config so that it will generate `django.wsgi` and so that regulations-core can be run with mod_wsgi.