### PR TITLE
fix for duplicate labels in notice

### DIFF
--- a/regcore/db/django_models.py
+++ b/regcore/db/django_models.py
@@ -102,7 +102,8 @@ class DMNotices(object):
         if 'effective_on' in notice:
             model.effective_on = notice['effective_on']
         model.save()
-        for cfr_part in notice.get('cfr_parts', []):
+        cfr_parts = set(notice.get('cfr_parts', []))
+        for cfr_part in cfr_parts:
             model.noticecfrpart_set.create(cfr_part=cfr_part)
 
     def get(self, doc_number):


### PR DESCRIPTION
Somehow the notices acquired a duplicate label which violated a table constraint. This fixes it by eliminating duplicates.