### PR TITLE
Django 1.5?!

### DIFF
--- a/regcore/tests/db_django_models_tests.py
+++ b/regcore/tests/db_django_models_tests.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 
 from regcore.db.django_models import *
 from regcore.models import Diff, Layer, Notice, Regulation
@@ -44,7 +44,7 @@ class ReusableDMRegulations(object):
         self.assertEqual([('ver1', '1111'), ('ver2', '1111')], results)
 
 
-class DMRegulationsTest(TestCase, ReusableDMRegulations):
+class DMRegulationsTest(TransactionTestCase, ReusableDMRegulations):
     def setUp(self):
         Regulation.objects.all().delete()
         self.dmr = DMRegulations()

--- a/regcore/tests/db_splitter_tests.py
+++ b/regcore/tests/db_splitter_tests.py
@@ -2,7 +2,7 @@
 
 from datetime import date
 
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 from mock import patch
 
 from regcore.db.splitter import *
@@ -10,7 +10,7 @@ from regcore.models import Diff, Layer, Notice, Regulation
 from regcore.tests import db_django_models_tests as dm
 
 
-class SplitterRegulationsTest(TestCase, dm.ReusableDMRegulations):
+class SplitterRegulationsTest(TransactionTestCase, dm.ReusableDMRegulations):
     @patch('regcore.db.es.ElasticSearch')
     def setUp(self, es):
         Regulation.objects.all().delete()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 anyjson
-django==1.5
+django==1.6
 django-haystack
 jsonschema
 pyelasticsearch


### PR DESCRIPTION
Require at least Django 1.6 for the manual transaction management we’re doing.