### PR TITLE
Store notices separately for each applicable regulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.swp
 .coverage
 local_settings.py
+*.db
+*.egg-info/
+.DS_Store

--- a/regcore/db/django_models.py
+++ b/regcore/db/django_models.py
@@ -106,35 +106,39 @@ class DMLayers(object):
 
 class DMNotices(object):
     """Implementation of Django-models as notice backend"""
-    def put(self, doc_number, notice):
-        """Store a single notice"""
-        Notice.objects.filter(document_number=doc_number).delete()
+
+    def put(self, doc_number, part, notice):
+        """ Store a single notice """
+
+        Notice.objects.filter(document_number=doc_number,
+                cfr_part=part).delete()
 
         model = Notice(document_number=doc_number,
+                       cfr_part=part,
                        fr_url=notice['fr_url'],
                        publication_date=notice['publication_date'],
                        notice=notice)
+
         if 'effective_on' in notice:
             model.effective_on = notice['effective_on']
-        model.save()
-        cfr_parts = set(notice.get('cfr_parts', []))
-        for cfr_part in cfr_parts:
-            model.noticecfrpart_set.create(cfr_part=cfr_part)
 
-    def get(self, doc_number):
-        """Find the associated notice"""
+        model.save()
+
+    def get(self, doc_number, part):
+        """ Find the associated notice """
         try:
             return Notice.objects.get(
-                document_number=doc_number).notice
+                document_number=doc_number, cfr_part=part).notice
         except ObjectDoesNotExist:
             return None
 
     def listing(self, part=None):
-        """All notices or filtered by cfr_part"""
+        """ All notices or filtered by cfr_part """
         query = Notice.objects
-        if part:
-            query = query.filter(noticecfrpart__cfr_part=part)
-        results = query.values('document_number', 'effective_on', 'fr_url',
+        if part is not None:
+            query = query.filter(cfr_part=part)
+        results = query.values('document_number', 'cfr_part', 
+                               'effective_on', 'fr_url', 
                                'publication_date')
         for result in results:
             for key in ('effective_on', 'publication_date'):

--- a/regcore/db/splitter.py
+++ b/regcore/db/splitter.py
@@ -45,9 +45,9 @@ class SplitterNotices(object):
         self.get = self.dm.get
         self.listing = self.dm.listing
 
-    def put(self, doc_number, notice):
+    def put(self, doc_number, part, notice):
         """Write to both"""
-        self.dm.put(doc_number, notice)
+        self.dm.put(doc_number, part, notice)
         self.es.put(doc_number, notice)
 
 

--- a/regcore/migrations/0011_auto__chg_field_layer_label__chg_field_re.py
+++ b/regcore/migrations/0011_auto__chg_field_layer_label__chg_field_re.py
@@ -10,6 +10,18 @@ class Migration(SchemaMigration):
     def forwards(self, orm):
 
         # Changing field 'Layer.label'
+        db.alter_column(u'regcore_layer', 'label', self.gf('django.db.models.fields.SlugField')(max_length=200))
+
+        # Changing field 'Regulation.label_string'
+        db.alter_column(u'regcore_regulation', 'label_string', self.gf('django.db.models.fields.SlugField')(max_length=200))
+
+        # Changing field 'Diff.label'
+        db.alter_column(u'regcore_diff', 'label', self.gf('django.db.models.fields.SlugField')(max_length=200))
+
+
+    def backwards(self, orm):
+
+        # Changing field 'Layer.label'
         db.alter_column(u'regcore_layer', 'label', self.gf('django.db.models.fields.SlugField')(max_length=100))
 
         # Changing field 'Regulation.label_string'
@@ -18,30 +30,19 @@ class Migration(SchemaMigration):
         # Changing field 'Diff.label'
         db.alter_column(u'regcore_diff', 'label', self.gf('django.db.models.fields.SlugField')(max_length=100))
 
-    def backwards(self, orm):
-
-        # Changing field 'Layer.label'
-        db.alter_column(u'regcore_layer', 'label', self.gf('django.db.models.fields.SlugField')(max_length=50))
-
-        # Changing field 'Regulation.label_string'
-        db.alter_column(u'regcore_regulation', 'label_string', self.gf('django.db.models.fields.SlugField')(max_length=50))
-
-        # Changing field 'Diff.label'
-        db.alter_column(u'regcore_diff', 'label', self.gf('django.db.models.fields.SlugField')(max_length=50))
-
     models = {
         u'regcore.diff': {
             'Meta': {'unique_together': "(('label', 'old_version', 'new_version'),)", 'object_name': 'Diff', 'index_together': "(('label', 'old_version', 'new_version'),)"},
             'diff': ('regcore.fields.CompressedJSONField', [], {}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'label': ('django.db.models.fields.SlugField', [], {'max_length': '100'}),
+            'label': ('django.db.models.fields.SlugField', [], {'max_length': '200'}),
             'new_version': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
             'old_version': ('django.db.models.fields.SlugField', [], {'max_length': '20'})
         },
         u'regcore.layer': {
             'Meta': {'unique_together': "(('version', 'name', 'label'),)", 'object_name': 'Layer', 'index_together': "(('version', 'name', 'label'),)"},
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'label': ('django.db.models.fields.SlugField', [], {'max_length': '100'}),
+            'label': ('django.db.models.fields.SlugField', [], {'max_length': '200'}),
             'layer': ('regcore.fields.CompressedJSONField', [], {}),
             'name': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
             'version': ('django.db.models.fields.SlugField', [], {'max_length': '20'})
@@ -64,7 +65,7 @@ class Migration(SchemaMigration):
             'Meta': {'unique_together': "(('version', 'label_string'),)", 'object_name': 'Regulation', 'index_together': "(('version', 'label_string'),)"},
             'children': ('regcore.fields.CompressedJSONField', [], {}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'label_string': ('django.db.models.fields.SlugField', [], {'max_length': '100'}),
+            'label_string': ('django.db.models.fields.SlugField', [], {'max_length': '200'}),
             'marker': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '10'}),
             'node_type': ('django.db.models.fields.SlugField', [], {'max_length': '10'}),
             'root': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),

--- a/regcore/migrations/0012_auto__add_newnotice__add_unique_newnotice_document_number_cfr_part__ad.py
+++ b/regcore/migrations/0012_auto__add_newnotice__add_unique_newnotice_document_number_cfr_part__ad.py
@@ -8,43 +8,62 @@ from django.db import models
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
+        # Adding model 'NewNotice'
+        db.create_table(u'regcore_newnotice', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('document_number', self.gf('django.db.models.fields.SlugField')(max_length=20)),
+            ('cfr_part', self.gf('django.db.models.fields.SlugField')(max_length=200)),
+            ('effective_on', self.gf('django.db.models.fields.DateField')(null=True)),
+            ('fr_url', self.gf('django.db.models.fields.CharField')(max_length=200)),
+            ('publication_date', self.gf('django.db.models.fields.DateField')()),
+            ('notice', self.gf('regcore.fields.CompressedJSONField')()),
+        ))
+        db.send_create_signal(u'regcore', ['NewNotice'])
 
-        # Changing field 'Layer.label'
-        db.alter_column(u'regcore_layer', 'label', self.gf('django.db.models.fields.SlugField')(max_length=100))
+        # Adding unique constraint on 'NewNotice', fields ['document_number', 'cfr_part']
+        db.create_unique(u'regcore_newnotice', ['document_number', 'cfr_part'])
 
-        # Changing field 'Regulation.label_string'
-        db.alter_column(u'regcore_regulation', 'label_string', self.gf('django.db.models.fields.SlugField')(max_length=100))
+        # Adding index on 'NewNotice', fields ['document_number', 'cfr_part']
+        db.create_index(u'regcore_newnotice', ['document_number', 'cfr_part'])
 
-        # Changing field 'Diff.label'
-        db.alter_column(u'regcore_diff', 'label', self.gf('django.db.models.fields.SlugField')(max_length=100))
 
     def backwards(self, orm):
+        # Removing index on 'NewNotice', fields ['document_number', 'cfr_part']
+        db.delete_index(u'regcore_newnotice', ['document_number', 'cfr_part'])
 
-        # Changing field 'Layer.label'
-        db.alter_column(u'regcore_layer', 'label', self.gf('django.db.models.fields.SlugField')(max_length=50))
+        # Removing unique constraint on 'NewNotice', fields ['document_number', 'cfr_part']
+        db.delete_unique(u'regcore_newnotice', ['document_number', 'cfr_part'])
 
-        # Changing field 'Regulation.label_string'
-        db.alter_column(u'regcore_regulation', 'label_string', self.gf('django.db.models.fields.SlugField')(max_length=50))
+        # Deleting model 'NewNotice'
+        db.delete_table(u'regcore_newnotice')
 
-        # Changing field 'Diff.label'
-        db.alter_column(u'regcore_diff', 'label', self.gf('django.db.models.fields.SlugField')(max_length=50))
 
     models = {
         u'regcore.diff': {
             'Meta': {'unique_together': "(('label', 'old_version', 'new_version'),)", 'object_name': 'Diff', 'index_together': "(('label', 'old_version', 'new_version'),)"},
             'diff': ('regcore.fields.CompressedJSONField', [], {}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'label': ('django.db.models.fields.SlugField', [], {'max_length': '100'}),
+            'label': ('django.db.models.fields.SlugField', [], {'max_length': '200'}),
             'new_version': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
             'old_version': ('django.db.models.fields.SlugField', [], {'max_length': '20'})
         },
         u'regcore.layer': {
             'Meta': {'unique_together': "(('version', 'name', 'label'),)", 'object_name': 'Layer', 'index_together': "(('version', 'name', 'label'),)"},
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'label': ('django.db.models.fields.SlugField', [], {'max_length': '100'}),
+            'label': ('django.db.models.fields.SlugField', [], {'max_length': '200'}),
             'layer': ('regcore.fields.CompressedJSONField', [], {}),
             'name': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
             'version': ('django.db.models.fields.SlugField', [], {'max_length': '20'})
+        },
+        u'regcore.newnotice': {
+            'Meta': {'unique_together': "(('document_number', 'cfr_part'),)", 'object_name': 'NewNotice', 'index_together': "(('document_number', 'cfr_part'),)"},
+            'cfr_part': ('django.db.models.fields.SlugField', [], {'max_length': '200'}),
+            'document_number': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
+            'effective_on': ('django.db.models.fields.DateField', [], {'null': 'True'}),
+            'fr_url': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'notice': ('regcore.fields.CompressedJSONField', [], {}),
+            'publication_date': ('django.db.models.fields.DateField', [], {})
         },
         u'regcore.notice': {
             'Meta': {'object_name': 'Notice'},
@@ -64,7 +83,7 @@ class Migration(SchemaMigration):
             'Meta': {'unique_together': "(('version', 'label_string'),)", 'object_name': 'Regulation', 'index_together': "(('version', 'label_string'),)"},
             'children': ('regcore.fields.CompressedJSONField', [], {}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'label_string': ('django.db.models.fields.SlugField', [], {'max_length': '100'}),
+            'label_string': ('django.db.models.fields.SlugField', [], {'max_length': '200'}),
             'marker': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '10'}),
             'node_type': ('django.db.models.fields.SlugField', [], {'max_length': '10'}),
             'root': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),

--- a/regcore/migrations/0013_new_notice.py
+++ b/regcore/migrations/0013_new_notice.py
@@ -16,6 +16,7 @@ class Migration(DataMigration):
                 new_notice = orm.NewNotice(
                         document_number=notice.document_number,
                         cfr_part=cfr_part.cfr_part,
+                        effective_on=notice.effective_on,
                         fr_url=notice.fr_url,
                         publication_date=notice.publication_date,
                         notice=notice.notice)
@@ -36,6 +37,7 @@ class Migration(DataMigration):
                 if len(existing_notices) == 0 \
                 else orm.Notice(
                     document_number=notice.document_number,
+                    effective_on=notice.effective_on,
                     fr_url=notice.fr_url,
                     publication_date=notice.publication_date,
                     notice=notice.notice)

--- a/regcore/migrations/0013_new_notice.py
+++ b/regcore/migrations/0013_new_notice.py
@@ -1,50 +1,76 @@
 # -*- coding: utf-8 -*-
 from south.utils import datetime_utils as datetime
 from south.db import db
-from south.v2 import SchemaMigration
+from south.v2 import DataMigration
 from django.db import models
 
-
-class Migration(SchemaMigration):
+class Migration(DataMigration):
 
     def forwards(self, orm):
-
-        # Changing field 'Layer.label'
-        db.alter_column(u'regcore_layer', 'label', self.gf('django.db.models.fields.SlugField')(max_length=100))
-
-        # Changing field 'Regulation.label_string'
-        db.alter_column(u'regcore_regulation', 'label_string', self.gf('django.db.models.fields.SlugField')(max_length=100))
-
-        # Changing field 'Diff.label'
-        db.alter_column(u'regcore_diff', 'label', self.gf('django.db.models.fields.SlugField')(max_length=100))
+        """ Create NewNotice instances for each Notice AND NoticeCFRPart """
+        # We're going to create a new notice for every existing notice.
+        for notice in orm.Notice.objects.all():
+            # We need to create a new notice for each notice AND
+            # cfr_part it applies to. 
+            for cfr_part in notice.noticecfrpart_set.all():
+                new_notice = orm.NewNotice(
+                        document_number=notice.document_number,
+                        cfr_part=cfr_part.cfr_part,
+                        fr_url=notice.fr_url,
+                        publication_date=notice.publication_date,
+                        notice=notice.notice)
+                new_notice.save()
 
     def backwards(self, orm):
+        """ Create Notice AND NoticeCFRPart instances for each NewNotice """
+        # For each NewNotice instance, we need to create a
+        # NoticeCFRPart, and for each unique document number create a
+        # Notice instance.
+        for notice in orm.NewNotice.objects.all():
+            # See if there is already a Notice with the document number,
+            # if not, create it.
+            existing_notices = Notice.objects.filter(
+                document_number=notice.document_number)
 
-        # Changing field 'Layer.label'
-        db.alter_column(u'regcore_layer', 'label', self.gf('django.db.models.fields.SlugField')(max_length=50))
+            new_notice = existing_notices[0] \
+                if len(existing_notices) == 0 \
+                else orm.Notice(
+                    document_number=notice.document_number,
+                    fr_url=notice.fr_url,
+                    publication_date=notice.publication_date,
+                    notice=notice.notice)
 
-        # Changing field 'Regulation.label_string'
-        db.alter_column(u'regcore_regulation', 'label_string', self.gf('django.db.models.fields.SlugField')(max_length=50))
+            # Add the CFR part
+            new_notice.noticecfrpart_set.create(cfr_part=notice.cfr_part)
 
-        # Changing field 'Diff.label'
-        db.alter_column(u'regcore_diff', 'label', self.gf('django.db.models.fields.SlugField')(max_length=50))
+            new_notice.save()
 
     models = {
         u'regcore.diff': {
             'Meta': {'unique_together': "(('label', 'old_version', 'new_version'),)", 'object_name': 'Diff', 'index_together': "(('label', 'old_version', 'new_version'),)"},
             'diff': ('regcore.fields.CompressedJSONField', [], {}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'label': ('django.db.models.fields.SlugField', [], {'max_length': '100'}),
+            'label': ('django.db.models.fields.SlugField', [], {'max_length': '200'}),
             'new_version': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
             'old_version': ('django.db.models.fields.SlugField', [], {'max_length': '20'})
         },
         u'regcore.layer': {
             'Meta': {'unique_together': "(('version', 'name', 'label'),)", 'object_name': 'Layer', 'index_together': "(('version', 'name', 'label'),)"},
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'label': ('django.db.models.fields.SlugField', [], {'max_length': '100'}),
+            'label': ('django.db.models.fields.SlugField', [], {'max_length': '200'}),
             'layer': ('regcore.fields.CompressedJSONField', [], {}),
             'name': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
             'version': ('django.db.models.fields.SlugField', [], {'max_length': '20'})
+        },
+        u'regcore.newnotice': {
+            'Meta': {'unique_together': "(('document_number', 'cfr_part'),)", 'object_name': 'NewNotice', 'index_together': "(('document_number', 'cfr_part'),)"},
+            'cfr_part': ('django.db.models.fields.SlugField', [], {'max_length': '200'}),
+            'document_number': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
+            'effective_on': ('django.db.models.fields.DateField', [], {'null': 'True'}),
+            'fr_url': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'notice': ('regcore.fields.CompressedJSONField', [], {}),
+            'publication_date': ('django.db.models.fields.DateField', [], {})
         },
         u'regcore.notice': {
             'Meta': {'object_name': 'Notice'},
@@ -64,7 +90,7 @@ class Migration(SchemaMigration):
             'Meta': {'unique_together': "(('version', 'label_string'),)", 'object_name': 'Regulation', 'index_together': "(('version', 'label_string'),)"},
             'children': ('regcore.fields.CompressedJSONField', [], {}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'label_string': ('django.db.models.fields.SlugField', [], {'max_length': '100'}),
+            'label_string': ('django.db.models.fields.SlugField', [], {'max_length': '200'}),
             'marker': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '10'}),
             'node_type': ('django.db.models.fields.SlugField', [], {'max_length': '10'}),
             'root': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
@@ -75,3 +101,4 @@ class Migration(SchemaMigration):
     }
 
     complete_apps = ['regcore']
+    symmetrical = True

--- a/regcore/migrations/0014_auto__del_notice__del_noticecfrpart__del_unique_noticecfrpart_notice_c.py
+++ b/regcore/migrations/0014_auto__del_notice__del_noticecfrpart__del_unique_noticecfrpart_notice_c.py
@@ -8,63 +8,77 @@ from django.db import models
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
+        # Removing unique constraint on 'NoticeCFRPart', fields ['notice', 'cfr_part']
+        db.delete_unique(u'regcore_noticecfrpart', ['notice_id', 'cfr_part'])
 
-        # Changing field 'Layer.label'
-        db.alter_column(u'regcore_layer', 'label', self.gf('django.db.models.fields.SlugField')(max_length=100))
+        # Removing index on 'NoticeCFRPart', fields ['notice', 'cfr_part']
+        db.delete_index(u'regcore_noticecfrpart', ['notice_id', 'cfr_part'])
 
-        # Changing field 'Regulation.label_string'
-        db.alter_column(u'regcore_regulation', 'label_string', self.gf('django.db.models.fields.SlugField')(max_length=100))
+        # Deleting model 'Notice'
+        db.delete_table(u'regcore_notice')
 
-        # Changing field 'Diff.label'
-        db.alter_column(u'regcore_diff', 'label', self.gf('django.db.models.fields.SlugField')(max_length=100))
+        # Deleting model 'NoticeCFRPart'
+        db.delete_table(u'regcore_noticecfrpart')
+
 
     def backwards(self, orm):
+        # Adding index on 'NoticeCFRPart', fields ['notice', 'cfr_part']
+        db.create_index(u'regcore_noticecfrpart', ['notice_id', 'cfr_part'])
 
-        # Changing field 'Layer.label'
-        db.alter_column(u'regcore_layer', 'label', self.gf('django.db.models.fields.SlugField')(max_length=50))
+        # Adding model 'Notice'
+        db.create_table(u'regcore_notice', (
+            ('notice', self.gf('regcore.fields.CompressedJSONField')()),
+            ('effective_on', self.gf('django.db.models.fields.DateField')(null=True)),
+            ('document_number', self.gf('django.db.models.fields.SlugField')(max_length=20, primary_key=True)),
+            ('fr_url', self.gf('django.db.models.fields.CharField')(max_length=200)),
+            ('publication_date', self.gf('django.db.models.fields.DateField')()),
+        ))
+        db.send_create_signal(u'regcore', ['Notice'])
 
-        # Changing field 'Regulation.label_string'
-        db.alter_column(u'regcore_regulation', 'label_string', self.gf('django.db.models.fields.SlugField')(max_length=50))
+        # Adding model 'NoticeCFRPart'
+        db.create_table(u'regcore_noticecfrpart', (
+            ('notice', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['regcore.Notice'])),
+            ('cfr_part', self.gf('django.db.models.fields.SlugField')(max_length=10)),
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+        ))
+        db.send_create_signal(u'regcore', ['NoticeCFRPart'])
 
-        # Changing field 'Diff.label'
-        db.alter_column(u'regcore_diff', 'label', self.gf('django.db.models.fields.SlugField')(max_length=50))
+        # Adding unique constraint on 'NoticeCFRPart', fields ['notice', 'cfr_part']
+        db.create_unique(u'regcore_noticecfrpart', ['notice_id', 'cfr_part'])
+
 
     models = {
         u'regcore.diff': {
             'Meta': {'unique_together': "(('label', 'old_version', 'new_version'),)", 'object_name': 'Diff', 'index_together': "(('label', 'old_version', 'new_version'),)"},
             'diff': ('regcore.fields.CompressedJSONField', [], {}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'label': ('django.db.models.fields.SlugField', [], {'max_length': '100'}),
+            'label': ('django.db.models.fields.SlugField', [], {'max_length': '200'}),
             'new_version': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
             'old_version': ('django.db.models.fields.SlugField', [], {'max_length': '20'})
         },
         u'regcore.layer': {
             'Meta': {'unique_together': "(('version', 'name', 'label'),)", 'object_name': 'Layer', 'index_together': "(('version', 'name', 'label'),)"},
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'label': ('django.db.models.fields.SlugField', [], {'max_length': '100'}),
+            'label': ('django.db.models.fields.SlugField', [], {'max_length': '200'}),
             'layer': ('regcore.fields.CompressedJSONField', [], {}),
             'name': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
             'version': ('django.db.models.fields.SlugField', [], {'max_length': '20'})
         },
-        u'regcore.notice': {
-            'Meta': {'object_name': 'Notice'},
-            'document_number': ('django.db.models.fields.SlugField', [], {'max_length': '20', 'primary_key': 'True'}),
+        u'regcore.newnotice': {
+            'Meta': {'unique_together': "(('document_number', 'cfr_part'),)", 'object_name': 'NewNotice', 'index_together': "(('document_number', 'cfr_part'),)"},
+            'cfr_part': ('django.db.models.fields.SlugField', [], {'max_length': '200'}),
+            'document_number': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
             'effective_on': ('django.db.models.fields.DateField', [], {'null': 'True'}),
             'fr_url': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'notice': ('regcore.fields.CompressedJSONField', [], {}),
             'publication_date': ('django.db.models.fields.DateField', [], {})
-        },
-        u'regcore.noticecfrpart': {
-            'Meta': {'unique_together': "(('notice', 'cfr_part'),)", 'object_name': 'NoticeCFRPart', 'index_together': "(('notice', 'cfr_part'),)"},
-            'cfr_part': ('django.db.models.fields.SlugField', [], {'max_length': '10'}),
-            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'notice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['regcore.Notice']"})
         },
         u'regcore.regulation': {
             'Meta': {'unique_together': "(('version', 'label_string'),)", 'object_name': 'Regulation', 'index_together': "(('version', 'label_string'),)"},
             'children': ('regcore.fields.CompressedJSONField', [], {}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'label_string': ('django.db.models.fields.SlugField', [], {'max_length': '100'}),
+            'label_string': ('django.db.models.fields.SlugField', [], {'max_length': '200'}),
             'marker': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '10'}),
             'node_type': ('django.db.models.fields.SlugField', [], {'max_length': '10'}),
             'root': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),

--- a/regcore/migrations/0015_auto__del_newnotice__del_unique_newnotice_document_number_cfr_part__de.py
+++ b/regcore/migrations/0015_auto__del_newnotice__del_unique_newnotice_document_number_cfr_part__de.py
@@ -8,63 +8,71 @@ from django.db import models
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
+        # Removing unique constraint on 'NewNotice', fields ['document_number', 'cfr_part']
+        db.delete_unique(u'regcore_newnotice', ['document_number', 'cfr_part'])
 
-        # Changing field 'Layer.label'
-        db.alter_column(u'regcore_layer', 'label', self.gf('django.db.models.fields.SlugField')(max_length=100))
+        # Removing index on 'NewNotice', fields ['document_number', 'cfr_part']
+        db.delete_index(u'regcore_newnotice', ['document_number', 'cfr_part'])
 
-        # Changing field 'Regulation.label_string'
-        db.alter_column(u'regcore_regulation', 'label_string', self.gf('django.db.models.fields.SlugField')(max_length=100))
+        # Rename the table
+        db.rename_table(u'regcore_newnotice', u'regcore_notice')
 
-        # Changing field 'Diff.label'
-        db.alter_column(u'regcore_diff', 'label', self.gf('django.db.models.fields.SlugField')(max_length=100))
+        # Adding unique constraint on 'Notice', fields ['document_number', 'cfr_part']
+        db.create_unique(u'regcore_notice', ['document_number', 'cfr_part'])
+
+        # Adding index on 'Notice', fields ['document_number', 'cfr_part']
+        db.create_index(u'regcore_notice', ['document_number', 'cfr_part'])
+
 
     def backwards(self, orm):
+        # Removing index on 'Notice', fields ['document_number', 'cfr_part']
+        db.delete_index(u'regcore_notice', ['document_number', 'cfr_part'])
 
-        # Changing field 'Layer.label'
-        db.alter_column(u'regcore_layer', 'label', self.gf('django.db.models.fields.SlugField')(max_length=50))
+        # Removing unique constraint on 'Notice', fields ['document_number', 'cfr_part']
+        db.delete_unique(u'regcore_notice', ['document_number', 'cfr_part'])
 
-        # Changing field 'Regulation.label_string'
-        db.alter_column(u'regcore_regulation', 'label_string', self.gf('django.db.models.fields.SlugField')(max_length=50))
+        # Rename the table
+        db.rename_table(u'regcore_notice', u'regcore_newnotice')
 
-        # Changing field 'Diff.label'
-        db.alter_column(u'regcore_diff', 'label', self.gf('django.db.models.fields.SlugField')(max_length=50))
+        # Adding index on 'NewNotice', fields ['document_number', 'cfr_part']
+        db.create_index(u'regcore_newnotice', ['document_number', 'cfr_part'])
+
+        # Adding unique constraint on 'NewNotice', fields ['document_number', 'cfr_part']
+        db.create_unique(u'regcore_newnotice', ['document_number', 'cfr_part'])
+
 
     models = {
         u'regcore.diff': {
             'Meta': {'unique_together': "(('label', 'old_version', 'new_version'),)", 'object_name': 'Diff', 'index_together': "(('label', 'old_version', 'new_version'),)"},
             'diff': ('regcore.fields.CompressedJSONField', [], {}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'label': ('django.db.models.fields.SlugField', [], {'max_length': '100'}),
+            'label': ('django.db.models.fields.SlugField', [], {'max_length': '200'}),
             'new_version': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
             'old_version': ('django.db.models.fields.SlugField', [], {'max_length': '20'})
         },
         u'regcore.layer': {
             'Meta': {'unique_together': "(('version', 'name', 'label'),)", 'object_name': 'Layer', 'index_together': "(('version', 'name', 'label'),)"},
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'label': ('django.db.models.fields.SlugField', [], {'max_length': '100'}),
+            'label': ('django.db.models.fields.SlugField', [], {'max_length': '200'}),
             'layer': ('regcore.fields.CompressedJSONField', [], {}),
             'name': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
             'version': ('django.db.models.fields.SlugField', [], {'max_length': '20'})
         },
         u'regcore.notice': {
-            'Meta': {'object_name': 'Notice'},
-            'document_number': ('django.db.models.fields.SlugField', [], {'max_length': '20', 'primary_key': 'True'}),
+            'Meta': {'unique_together': "(('document_number', 'cfr_part'),)", 'object_name': 'Notice', 'index_together': "(('document_number', 'cfr_part'),)"},
+            'cfr_part': ('django.db.models.fields.SlugField', [], {'max_length': '200'}),
+            'document_number': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
             'effective_on': ('django.db.models.fields.DateField', [], {'null': 'True'}),
             'fr_url': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'notice': ('regcore.fields.CompressedJSONField', [], {}),
             'publication_date': ('django.db.models.fields.DateField', [], {})
-        },
-        u'regcore.noticecfrpart': {
-            'Meta': {'unique_together': "(('notice', 'cfr_part'),)", 'object_name': 'NoticeCFRPart', 'index_together': "(('notice', 'cfr_part'),)"},
-            'cfr_part': ('django.db.models.fields.SlugField', [], {'max_length': '10'}),
-            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'notice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['regcore.Notice']"})
         },
         u'regcore.regulation': {
             'Meta': {'unique_together': "(('version', 'label_string'),)", 'object_name': 'Regulation', 'index_together': "(('version', 'label_string'),)"},
             'children': ('regcore.fields.CompressedJSONField', [], {}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'label_string': ('django.db.models.fields.SlugField', [], {'max_length': '100'}),
+            'label_string': ('django.db.models.fields.SlugField', [], {'max_length': '200'}),
             'marker': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '10'}),
             'node_type': ('django.db.models.fields.SlugField', [], {'max_length': '10'}),
             'root': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),

--- a/regcore/models.py
+++ b/regcore/models.py
@@ -30,21 +30,16 @@ class Layer(models.Model):
 
 
 class Notice(models.Model):
-    document_number = models.SlugField(max_length=20, primary_key=True)
+    document_number = models.SlugField(max_length=20)
+    cfr_part = models.SlugField(max_length=200)
     effective_on = models.DateField(null=True)
     fr_url = models.CharField(max_length=200)
     publication_date = models.DateField()
     notice = CompressedJSONField()
 
-
-class NoticeCFRPart(models.Model):
-    """Represents the one-to-many relationship between notices and CFR parts"""
-    cfr_part = models.SlugField(max_length=10, db_index=True)
-    notice = models.ForeignKey(Notice)
-
     class Meta:
-        index_together = (('notice', 'cfr_part'),)
-        unique_together = (('notice', 'cfr_part'),)
+        index_together = (('document_number', 'cfr_part'),)
+        unique_together = (('document_number', 'cfr_part'),)
 
 
 class Diff(models.Model):

--- a/regcore/tests/db_splitter_tests.py
+++ b/regcore/tests/db_splitter_tests.py
@@ -153,7 +153,7 @@ class SplitterNoticesTest(TestCase, dm.ReusableDMNotices):
                'fr_url': 'http://example.com',
                'publication_date': '2010-02-02',
                'cfr_parts': ['222']}
-        sn.put('docdoc', doc)
+        sn.put('docdoc', '222', doc)
 
         notices = Notice.objects.all()
         self.assertEqual(1, len(notices))
@@ -161,9 +161,7 @@ class SplitterNoticesTest(TestCase, dm.ReusableDMNotices):
         self.assertEqual(date(2011, 1, 1), notices[0].effective_on)
         self.assertEqual('http://example.com', notices[0].fr_url)
         self.assertEqual(date(2010, 2, 2), notices[0].publication_date)
-        ncp = notices[0].noticecfrpart_set.all()
-        self.assertEqual(1, len(ncp))
-        self.assertEqual('222', ncp[0].cfr_part)
+        self.assertEqual('222', notices[0].cfr_part)
         self.assertEqual(doc, notices[0].notice)
 
         self.assertTrue(es.return_value.index.called)
@@ -182,14 +180,14 @@ class SplitterNoticesTest(TestCase, dm.ReusableDMNotices):
                'fr_url': 'http://example.com',
                'publication_date': '2010-02-02',
                'cfr_part': '222'}
-        sn.put('docdoc', doc)
+        sn.put('docdoc', '222', doc)
 
         notices = Notice.objects.all()
         self.assertEqual(1, len(notices))
         self.assertEqual('http://example.com', notices[0].fr_url)
 
         doc['fr_url'] = 'url2'
-        sn.put('docdoc', doc)
+        sn.put('docdoc', '222', doc)
 
         notices = Notice.objects.all()
         self.assertEqual(1, len(notices))

--- a/regcore/urls.py
+++ b/regcore/urls.py
@@ -54,7 +54,7 @@ urlpatterns = patterns(
                                        seg('version')),
                 'layer', mapping['layer']),
 
-    by_verb_url(r'^notice/%s/%s$' % (seg('part'), seg('docnum')),
+    by_verb_url(r'^notice/%s/%s$' % (seg('part_or_docnum'), seg('docnum')),
                 'notice', mapping['notice']),
     by_verb_url(r'^notice/%s$' % seg('part_or_docnum'),
                 'notices-for-part', mapping['notices']),

--- a/regcore/urls.py
+++ b/regcore/urls.py
@@ -48,16 +48,22 @@ urlpatterns = patterns(
     by_verb_url(r'^diff/%s/%s/%s$' % (seg('label_id'), seg('old_version'),
                                       seg('new_version')),
                 'diff', mapping['diff']),
+
     by_verb_url(r'^layer/%s/%s/%s$' % (seg('name'), seg('label_id'),
                                        seg('version')),
                 'layer', mapping['layer']),
-    by_verb_url(r'^notice/%s$' % seg('docnum'),
+
+    by_verb_url(r'^notice/%s/%s$' % (seg('part'), seg('docnum')),
                 'notice', mapping['notice']),
+    by_verb_url(r'^notice/%s$' % seg('part'),
+                'notice', mapping['notices']),
+    by_verb_url(r'^notice$', 'notices', mapping['notices']),
+
     by_verb_url(r'^regulation/%s/%s$' % (seg('label_id'), seg('version')),
                 'regulation', mapping['regulation']),
-    by_verb_url(r'^notice$', 'notices', mapping['notices']),
-    by_verb_url(r'^regulation$', 'all-reg-versions', mapping['reg-versions']),
     by_verb_url(r'^regulation/%s$' % seg('label_id'),
                 'reg-versions', mapping['reg-versions']),
+    by_verb_url(r'^regulation$', 'all-reg-versions', mapping['reg-versions']),
+
     by_verb_url(r'^search$', 'search', mapping['search'])
 )

--- a/regcore/urls.py
+++ b/regcore/urls.py
@@ -35,6 +35,7 @@ if 'regcore_write' in settings.INSTALLED_APPS:
         mapping['diff'][verb] = wdiff.add
         mapping['layer'][verb] = wlayer.add
         mapping['notice'][verb] = wnotice.add
+        mapping['notices'][verb] = wnotice.add_all
         mapping['regulation'][verb] = wregulation.add
 
 
@@ -55,8 +56,8 @@ urlpatterns = patterns(
 
     by_verb_url(r'^notice/%s/%s$' % (seg('part'), seg('docnum')),
                 'notice', mapping['notice']),
-    by_verb_url(r'^notice/%s$' % seg('part'),
-                'notice', mapping['notices']),
+    by_verb_url(r'^notice/%s$' % seg('part_or_docnum'),
+                'notices-for-part', mapping['notices']),
     by_verb_url(r'^notice$', 'notices', mapping['notices']),
 
     by_verb_url(r'^regulation/%s/%s$' % (seg('label_id'), seg('version')),

--- a/regcore_read/tests/views_notice_tests.py
+++ b/regcore_read/tests/views_notice_tests.py
@@ -12,13 +12,13 @@ class ViewsNoticeTest(TestCase):
     @patch('regcore_read.views.notice.db')
     def test_get_none(self, db):
         db.Notices.return_value.get.return_value = None
-        response = Client().get('/notice/docdoc')
+        response = Client().get('/notice/111/docdoc')
         self.assertEqual(404, response.status_code)
 
     @patch('regcore_read.views.notice.db')
     def test_get_results(self, db):
         db.Notices.return_value.get.return_value = {'example': 'response'}
-        response = Client().get('/notice/docdoc')
+        response = Client().get('/notice/111/docdoc')
         self.assertEqual(200, response.status_code)
         self.assertEqual({'example': 'response'},
                          json.loads(response.content))
@@ -30,3 +30,4 @@ class ViewsNoticeTest(TestCase):
         self.assertEqual(200, response.status_code)
         self.assertEqual({'results': [1, 2, 3]},
                          json.loads(response.content))
+

--- a/regcore_read/views/notice.py
+++ b/regcore_read/views/notice.py
@@ -5,7 +5,7 @@ from regcore.responses import four_oh_four, success
 def get(request, part_or_docnum, docnum):
     """ Find and return the notice with this docnum and part """
     part = part_or_docnum
-    notice = db.Notices().get(document_number=docnum, cfr_part=part)
+    notice = db.Notices().get(doc_number=docnum, part=part)
     if notice:
         return success(notice)
     else:

--- a/regcore_read/views/notice.py
+++ b/regcore_read/views/notice.py
@@ -2,8 +2,9 @@ from regcore import db
 from regcore.responses import four_oh_four, success
 
 
-def get(request, part, docnum):
+def get(request, part_or_docnum, docnum):
     """ Find and return the notice with this docnum and part """
+    part = part_or_docnum
     notice = db.Notices().get(document_number=docnum, cfr_part=part)
     if notice:
         return success(notice)
@@ -11,8 +12,9 @@ def get(request, part, docnum):
         return four_oh_four()
 
 
-def listing(request, part=None):
+def listing(request, part_or_docnum=None):
     """Find and return all notices"""
+    part = part_or_docnum
     return success({
         'results': db.Notices().listing(part=part)
     })

--- a/regcore_read/views/notice.py
+++ b/regcore_read/views/notice.py
@@ -2,17 +2,17 @@ from regcore import db
 from regcore.responses import four_oh_four, success
 
 
-def get(request, docnum):
-    """Find and return the notice with this docnum"""
-    notice = db.Notices().get(docnum)
+def get(request, part, docnum):
+    """ Find and return the notice with this docnum and part """
+    notice = db.Notices().get(document_number=docnum, cfr_part=part)
     if notice:
         return success(notice)
     else:
         return four_oh_four()
 
 
-def listing(request):
+def listing(request, part=None):
     """Find and return all notices"""
     return success({
-        'results': db.Notices().listing(request.GET.get('part', None))
+        'results': db.Notices().listing(part=part)
     })

--- a/regcore_write/tests/views_notice_tests.py
+++ b/regcore_write/tests/views_notice_tests.py
@@ -2,7 +2,7 @@ import json
 from unittest import TestCase
 
 from django.test.client import Client
-from mock import patch
+from mock import patch, call
 
 from regcore_write.views.notice import *
 
@@ -10,36 +10,40 @@ from regcore_write.views.notice import *
 class ViewsNoticeTest(TestCase):
 
     def test_add_not_json(self):
-        url = '/notice/docdoc'
-
+        url = '/notice/111/docdoc'
         response = Client().put(url, content_type='application/json',
                                 data='{Invalid}')
         self.assertEqual(400, response.status_code)
 
     @patch('regcore_write.views.notice.db')
-    def test_add_label_success(self, db):
-        url = '/notice/docdoc'
-
+    def test_add_success(self, db):
+        # Add a notice 
+        url = '/notice/111/docdoc'
         response = Client().put(url, content_type='application/json',
                                 data=json.dumps({'some': 'struct'}))
         self.assertTrue(db.Notices.return_value.put.called)
         args = db.Notices.return_value.put.call_args[0]
         self.assertEqual('docdoc', args[0])
-        self.assertEqual({'some': 'struct', 'cfr_parts': []}, args[1])
+        self.assertEqual('111', args[1])
+        self.assertEqual({'some': 'struct'}, args[2])
 
-        response = Client().put(
-            url, content_type='application/json',
-            data=json.dumps({'some': 'struct', 'cfr_part': '1111'}))
-        self.assertTrue(db.Notices.return_value.put.called)
-        args = db.Notices.return_value.put.call_args[0]
-        self.assertEqual('docdoc', args[0])
-        self.assertEqual({'some': 'struct', 'cfr_parts': ['1111']}, args[1])
+    @patch('regcore_write.views.notice.db')
+    def test_add_all_success(self, db):
 
-        response = Client().put(
-            url, content_type='application/json',
-            data=json.dumps({'some': 'struct', 'cfr_parts': ['111', '222']}))
+        # Add a notice that applies to multiple parts
+        url = '/notice/docdoc'
+        notice = {'some': 'struct',
+                  'cfr_parts': ['111', '222']}
+        response = Client().put(url, content_type='application/json',
+                                data=json.dumps(notice))
+
+        # This should result in multiple calls to the put method
+        calls = [
+            call(u'docdoc', '111', 
+                 {'some': 'struct', 'cfr_parts': ['111', '222']}),
+            call(u'docdoc', '222', 
+                 {'some': 'struct', 'cfr_parts': ['111', '222']}),
+        ]
         self.assertTrue(db.Notices.return_value.put.called)
-        args = db.Notices.return_value.put.call_args[0]
-        self.assertEqual('docdoc', args[0])
-        self.assertEqual({'some': 'struct', 'cfr_parts': ['111', '222']},
-                         args[1])
+        db.Notices.return_value.put.assert_has_calls(
+            calls, any_order=True)

--- a/regcore_write/views/notice.py
+++ b/regcore_write/views/notice.py
@@ -6,19 +6,41 @@ from regcore.responses import success, user_error
 
 
 @csrf_exempt
-def add(request, docnum):
-    """Add the notice to the db"""
+def add(request, part_or_docnum, docnum):
+    """ Add the notice to the db """
+    part = part_or_docnum
+
     try:
         notice = anyjson.deserialize(request.body)
     except ValueError:
         return user_error('invalid format')
 
-    #   @todo: write a schema that verifies the notice's structure
+    db.Notices().put(docnum, part, notice)
+    return success()
+
+@csrf_exempt
+def add_all(request, part_or_docnum):
+    """ Add the notice for all applicable CFR parts, as specified in the
+        notice body. """
+    # NOTE: Be absolutely certain if you're PUTing /notice/1234-12345
+    # that it actually does contain content for all the parts in cfr_parts.
+    docnum = part_or_docnum
+
+    try:
+        notice = anyjson.deserialize(request.body)
+    except ValueError:
+        return user_error('invalid format')
+
+    # This supports old-style notices that apply to multiple CFR parts.
     cfr_parts = notice.get('cfr_parts', [])
     if 'cfr_part' in notice:
         cfr_parts.append(notice['cfr_part'])
-        del notice['cfr_part']
     notice['cfr_parts'] = cfr_parts
 
-    db.Notices().put(docnum, notice)
+    for cfr_part in cfr_parts:
+        db.Notices().put(docnum, cfr_part, notice)
+
     return success()
+
+
+


### PR DESCRIPTION
This PR modifies the way regulations-core stores notices. 

Up to now notices have been parsed and stored as a whole, with all the notice content that applies to any regulation. This changes stores notices on a per-regulation basis. This is best exemplified through URLs, I think. 

All other content stored in regulations-core is stored per-regulation, i.e. `regulation/[PART NUMBER]/[DOCUMENT NUMBER]`. Notices, previously, were stored `notice/[DOCUMENT_NUMBER]`. This is fine if the notice includes content for all the applicable regulations, but it won't work if the notice does not. With [RegML](https://github.com/cfpb/regulations-schema), that won't be the case. 

To do this, this PR removes the separate `NoticeCFRPart` model, because there will no longer be a one-to-many relationship between notices and regulations. Instead there will be a `Notice` instance for each regulation a particular document number applies to. There are appropriate migrations to make this happen and migrate existing data (backwards migrations are included). 

*THIS IS A BREAKING CHANGE*

![atomicbomb](https://cloud.githubusercontent.com/assets/10562538/11691356/9d01b8a6-9e68-11e5-9da0-7ad5c9e58a70.gif)

This is accompanied by PRs for cfpb/regulations-parser#305, cfpb/regulations-site#762, and cfpb/regulations-stub#23.
