### PR TITLE
Pin to Django 1.8, not a specific patch version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-django==1.8.11
+django>=1.8,<=1.8.99
 django-haystack
 jsonschema


### PR DESCRIPTION
This PR removes the version pin to a specific patch version of Django and makes it a range for 1.8.
