### PR TITLE
Cap required Django version between 1.8 and 1.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
         'regcore': ['templates/search/indexes/regcore/regulation_text.txt'],
     },
     install_requires=[
-        'django',
+        'django>=1.8,<1.12',
         'django-haystack',
         'jsonschema',
     ],


### PR DESCRIPTION
To avoid issues with incompatibility with Django 2.0.