### PR TITLE
Support optional testing of other databases

### DIFF
--- a/regcore/settings/base.py
+++ b/regcore/settings/base.py
@@ -4,6 +4,8 @@ import os
 
 from django.utils.crypto import get_random_string
 
+import dj_database_url
+
 
 INSTALLED_APPS = [
     'haystack',
@@ -22,6 +24,9 @@ DATABASES = {
         'NAME': 'eregs.db'
     }
 }
+
+if 'DATABASE_URL' in os.environ:
+    DATABASES['default'] = dj_database_url.config()
 
 TEST_RUNNER = 'django_nose.runner.NoseTestSuiteRunner'
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,3 +5,4 @@ mock
 nose
 coverage
 coveralls
+dj-database-url==0.4.2


### PR DESCRIPTION
This change adds support for using the `DATABASE_URL` environment variable to specify Django's dev/test database, based on the [dj-database-url](https://github.com/kennethreitz/dj-database-url) package.

It lets you run tests against e.g. Postgres:

```sh
$ DATABASE_URL=postgres://user@localhost/db python manage.py test
```

It adds dj-database-url==0.4.2 to the test requirements as that matches the current version in cfgov-refresh.