### PR TITLE
Fix string formatting in delete_reg.py.example

### DIFF
--- a/regcore/management/commands/delete_reg.py.example
+++ b/regcore/management/commands/delete_reg.py.example
@@ -58,7 +58,7 @@ class Command(BaseCommand):
 
             # manually delete all the regulation elements
             for doc_number in doc_numbers:
-                logging.info('Deleting version {0} for regulation {1}', doc_number, reg)
+                logging.info('Deleting version {0} for regulation {1}'.format(doc_number, reg))
                 # delete all layer elements
                 cursor.execute(
                     'DELETE FROM regcore_layer WHERE version= %s', 
@@ -79,4 +79,4 @@ class Command(BaseCommand):
             for notice in notices:
                 notice.delete()
 
-        logging.info('Regulation {} has been wiped from the database!', reg)
+        logging.info('Regulation {} has been wiped from the database!'.format(reg))


### PR DESCRIPTION
The `delete_reg.py.example` file won't run as a management command because the string formatting wasn't handled correcting in the logging. This PR fixes that.